### PR TITLE
Update The_8X8_Matrix_Functions.h

### DIFF
--- a/CD77_NeoMatrix_8X8_panel_Fun_with_FastLED/The_8X8_Matrix_Functions.h
+++ b/CD77_NeoMatrix_8X8_panel_Fun_with_FastLED/The_8X8_Matrix_Functions.h
@@ -1,5 +1,5 @@
-#ifndef The_8X8_Matrix_Functions.h
-#define The_8X8_Matrix_Functions.h
+#ifndef The_8X8_Matrix_Functions_h
+#define The_8X8_Matrix_Functions_h
 
 // Functions for loop -----------------------------------------------------------------
 
@@ -100,7 +100,7 @@ void cd77_8X8_box_colorWipe(uint8_t ghue, uint16_t wait) {
 
  
 // Fills the NeoMatrix 8X8 panel - one square at a time
-void cd77_fullallbox_colorWipe(uint8_t ghue, uint16_t wait, uint8_t* boxarray, int x) { // Note: boxarray is the name of the array being used.  x is the number of members in the array being used.
+void cd77_fullallbox_colorWipe(uint8_t ghue, uint16_t wait, uint8_t* boxarray, uint16_t x) { // Note: boxarray is the name of the array being used.  x is the number of members in the array being used.
   
    for(uint16_t i=0; i<x; i++) {
      leds[boxarray[i]]=CHSV(ghue, 255,255);     


### PR DESCRIPTION
Fixes warning: ISO C++11 requires whitespace after the macro name
Fixes warning about comparison between signed and unsigned integer.