### PR TITLE
Update The_8x8_Arrays.h

### DIFF
--- a/CD77_NeoMatrix_8X8_panel_Fun_with_FastLED/The_8x8_Arrays.h
+++ b/CD77_NeoMatrix_8X8_panel_Fun_with_FastLED/The_8x8_Arrays.h
@@ -1,5 +1,5 @@
-#ifndef The_8x8_Arrays.h
-#define The_8x8_Arrays.h
+#ifndef The_8x8_Arrays_h
+#define The_8x8_Arrays_h
 
 
 // arrays for forward spiral


### PR DESCRIPTION
Fixes warning: ISO C++11 requires whitespace after the macro name